### PR TITLE
Treat HTTP response 201 from nexus an OK response

### DIFF
--- a/tasks/lib/index.js
+++ b/tasks/lib/index.js
@@ -90,10 +90,10 @@ var createAndUploadArtifacts = function (options, done) {
                 status = data;
             });
             childProcess.on('close', function (code) {
-                if (code !== 0 || (status !== "200" && status !== "201")) {
-                    cb("Status code " + status + " for " + targetUri, null);
-                } else {
+                if (status.substring(0, 1) == "2" || code == 0) {
                     cb(null, "Ok");
+                } else  {
+                    cb("Status code " + status + " for " + targetUri, null);
                 }
             });
         };


### PR DESCRIPTION
Hi,

I backported this commit from https://github.com/kwiatkk1/grunt-nexus-deployer/commit/3d57fc76f243c49f1bab6402e345f12a43d8d6b9 into the fork I made, so I can use nexus-deployer with gulp and got the bugfix because our nexus sends out 201 HTTP codes when updating existing snapshots. 

I saw there is already a condition for 201 code but it don't work, and I presume 2xx http codes family could always be treated as a success.

Please let me know if we can improve this somehow

Benoit
