### PR TITLE
fixed issue with curl failing for password ending with '&' sign

### DIFF
--- a/tasks/lib/index.js
+++ b/tasks/lib/index.js
@@ -72,7 +72,7 @@ var createAndUploadArtifacts = function (options, done) {
 
             if (options.auth) {
                 curlOptions.push('-u');
-                curlOptions.push(options.auth.username + ":" + options.auth.password);
+                curlOptions.push('"'+options.auth.username + ":" + options.auth.password+'"');
             }
 
             if (options.insecure) {


### PR DESCRIPTION
Curl requests are failing when passowrd is ending with '&'
