### PR TITLE
Removed asynchronous FS operations.

### DIFF
--- a/tasks/lib/index.js
+++ b/tasks/lib/index.js
@@ -40,12 +40,24 @@ var save = function (fileContent, pomDir, fileName) {
     fs.writeFileSync(pomDir + '/' + fileName + '.sha1', sha1(fileContent));
 };
 
+var directoryExists = function(dir) {
+    try {
+        return fs.statSync(dir).isDirectory();
+    } catch (e) {
+        // error is thrown by statSync when path does not exist
+        if (e.code === 'ENOENT') {
+            return false
+        }
+        throw e;
+    }
+};
+
 var createAndUploadArtifacts = function (options, done) {
     var pomDir = options.pomDir || 'test/poms';
 
     options.parallel = options.parallel === undefined ? false : options.parallel;
-    if (!fs.exists(pomDir)) {
-        fs.mkdir(pomDir);
+    if (!directoryExists(pomDir)) {
+        fs.mkdirSync(pomDir);
     }
 
 


### PR DESCRIPTION
When run by gulp on our Continuous Integration server, the file system tasks would occasionally run out of order. I compared nexus-deployer with grunt-nexus-deployer and found they had changed the fs functions to be synchronous. I made virtually the same changes in this branch.

These changes passed the unit tests and have been running on our CI server for a week without incident.
