### PR TITLE
Fixes error related to reaching maximum string length

### DIFF
--- a/tasks/lib/index.js
+++ b/tasks/lib/index.js
@@ -124,6 +124,11 @@ var createAndUploadArtifacts = function (options, done) {
         sha1Hash.update(binaryChunk);
     });
 
+    artifactStream.on('error', function(error) {
+        console.log(chalk.red(error));
+        done(error);
+    });
+
     artifactStream.on('end', function() {
 
         fs.writeFileSync(pomDir + '/artifact.' + options.packaging + '.md5', md5Hash.digest('hex'));

--- a/tasks/lib/index.js
+++ b/tasks/lib/index.js
@@ -113,16 +113,21 @@ var createAndUploadArtifacts = function (options, done) {
 
 
     var artifactStream = fs.createReadStream(options.artifact);
-    var artifactData = '';
+    var md5Hash = crypto.createHash('md5');
+    var sha1Hash = crypto.createHash('sha1');
 
     artifactStream.on('data', function(chunk) {
-        artifactData = artifactData + chunk.toString('binary');
+
+        var binaryChunk = chunk.toString('binary');
+
+        md5Hash.update(binaryChunk);
+        sha1Hash.update(binaryChunk);
     });
 
     artifactStream.on('end', function() {
 
-        fs.writeFileSync(pomDir + '/artifact.' + options.packaging + '.md5', md5(artifactData));
-        fs.writeFileSync(pomDir + '/artifact.' + options.packaging + '.sha1', sha1(artifactData));
+        fs.writeFileSync(pomDir + '/artifact.' + options.packaging + '.md5', md5Hash.digest('hex'));
+        fs.writeFileSync(pomDir + '/artifact.' + options.packaging + '.sha1', sha1Hash.digest('hex'));
 
         var uploads = {};
 


### PR DESCRIPTION
Base the hash on a `stream` instead of one big binary string read from `readFileSync` because `readFileSync` was causing trouble with larger files.

Here is the error stack related to the problem mentioned above.

``` shell
Error: "toString()" failed
   at Buffer.toString (buffer.js:500:11)
   at Object.fs.readFileSync (fs.js:552:33)
   at createAndUploadArtifacts (/Users/jeapelle/Dev/code/PROJECT/node_modules/nexus-deployer/tasks/lib/index.js:68:27)
   at module.exports (/Users/jeapelle/Dev/code/PROJECT/node_modules/nexus-deployer/tasks/lib/index.js:177:5)
   at Object.deploy (/Users/jeapelle/Dev/code/PROJECT/node_modules/nexus-deployer/index.js:13:12)
   at services.artifactService.getVersionNumber.then.e (/Users/jeapelle/Dev/code/PROJECT/gulp/tasks/publish.js:57:18)
   at tryCallOne (/Users/jeapelle/Dev/code/PROJECT/node_modules/promise/lib/core.js:37:12)
   at /Users/jeapelle/Dev/code/PROJECT/node_modules/promise/lib/core.js:123:15
   at flush (/Users/jeapelle/Dev/code/PROJECT/node_modules/asap/raw.js:50:29)
   at _combinedTickCallback (internal/process/next_tick.js:67:7)
   at process._tickCallback (internal/process/next_tick.js:98:9)
```

By putting breakpoints in the code we managed to find that it was coming from the `readFileSync` part that looked like this before

``` js
var artifactData = fs.readFileSync(options.artifact, {encoding: 'binary'});
fs.writeFileSync(pomDir + '/artifact.' + options.packaging + '.md5', md5(artifactData));
fs.writeFileSync(pomDir + '/artifact.' + options.packaging + '.sha1', sha1(artifactData));
```

and now looks something like this

``` js
var artifactStream = fs.createReadStream(options.artifact);
var md5Hash = crypto.createHash('md5');
var sha1Hash = crypto.createHash('sha1');

artifactStream.on('data', function(chunk) {

    var binaryChunk = chunk.toString('binary');

    md5Hash.update(binaryChunk);
    sha1Hash.update(binaryChunk);
});

artifactStream.on('error', function(error) {
    console.log(chalk.red(error));
    done(error);
});

artifactStream.on('end', function() {

    fs.writeFileSync(pomDir + '/artifact.' + options.packaging + '.md5', md5Hash.digest('hex'));
    fs.writeFileSync(pomDir + '/artifact.' + options.packaging + '.sha1', sha1Hash.digest('hex'));

    [ALL THE CODE THAT NEEDS THE HASH HERE]
})
```
