### PR TITLE
Questions about Calculate SHA1

### DIFF
--- a/tasks/lib/index.js
+++ b/tasks/lib/index.js
@@ -65,7 +65,8 @@ var createAndUploadArtifacts = function (options, done) {
     save(createFile('latest-metadata.xml', options), pomDir, 'inner.xml');
     save(createFile('pom.xml', options), pomDir, 'pom.xml');
 
-    var artifactData = fs.readFileSync(options.artifact, {encoding: 'binary'});
+    // var artifactData = fs.readFileSync(options.artifact, {encoding: 'binary'});
+    var artifactData = fs.readFileSync(options.artifact);
     fs.writeFileSync(pomDir + '/artifact.' + options.packaging + '.md5', md5(artifactData));
     fs.writeFileSync(pomDir + '/artifact.' + options.packaging + '.sha1', sha1(artifactData));
 


### PR DESCRIPTION
Hi guys,

First of all, thanks for your work. I'm not going want to merge this PR but I don't have any chances to submit my issues and talk with you guys directly.

I'm using `archiver` package to create the **zip** file and then upload it into my in-house nexus server, but I encounter one issue, the SHA1 value calculated by `nexus-deployer` is different with the one calculated by `openssl sha1 xxx.zip`, so that the validation failed.

Here is my code used to generate the zip file:

```
    const output = fs.createWriteStream(destZipFilePath)

    output.on('close', resolve)
    output.on('error', reject)

    archive.pipe(output)

    archive.bulk([{
      cwd: srcDir,
      src: ['**/*'],
      expand: true
    }])

    archive.finalize()
```

After digging a while, I removed the `encoding` configuration for the code below and then it works:

```
var artifactData = fs.readFileSync(options.artifact, {encoding: 'binary'});
```

Is there any idea for that? Or Is there something I had missed?

Thanks in advance! I'm looking forward to your response. :)

-zx
