### PR TITLE
Adding curl error logging & handling undefined curl status

### DIFF
--- a/tasks/lib/index.js
+++ b/tasks/lib/index.js
@@ -95,7 +95,10 @@ var createAndUploadArtifacts = function (options, done) {
 
             var curlCmd = ['curl', curlOptions.join(' '), targetUri].join(' ');
 
-            var childProcess = exec(curlCmd, execOptions, function () {
+            var childProcess = exec(curlCmd, execOptions, function (error) {
+                if (error) {
+                    console.log(chalk.red(error));
+                }
             });
             childProcess.stdout.on('data', function (data) {
                 status = data;

--- a/tasks/lib/index.js
+++ b/tasks/lib/index.js
@@ -104,7 +104,7 @@ var createAndUploadArtifacts = function (options, done) {
                 status = data;
             });
             childProcess.on('close', function (code) {
-                if (status.substring(0, 1) == "2" || code == 0) {
+                if ((status && status.substring(0, 1) == "2") || code == 0) {
                     cb(null, "Ok");
                 } else  {
                     cb("Status code " + status + " for " + targetUri, null);


### PR DESCRIPTION
We recently hit an issue when we moved our job to a new box that we forgot to install curl on. 

- This caused the status to be undefined
- It would have been a bit quicker to troubleshoot with some curl error logging

This PR fixes both.