### PR TITLE
increase ansi-styles version

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -13,9 +13,9 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
       "dependencies": {
         "ansi-styles": {
-          "version": "2.2.0",
-          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
+          "version": "2.2.1",
+          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "dependencies": {
             "color-convert": {
               "version": "1.0.0",


### PR DESCRIPTION
Increase ansi-styles version to 2.2.1 to fix the follow error.:

```npm ERR! fetch failed https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz
npm WARN retry will retry, error on last attempt: Error: fetch failed with status code 404
npm ERR! fetch failed https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz
npm WARN retry will retry, error on last attempt: Error: fetch failed with status code 404
```