### PR TITLE
Added npmignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+test/
+.gitignore
+.jshintrc
+.travis.yml
+npm-shrinkwrap.json

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -13,9 +13,9 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
       "dependencies": {
         "ansi-styles": {
-          "version": "2.2.0",
-          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
+          "version": "2.2.1",
+          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "dependencies": {
             "color-convert": {
               "version": "1.0.0",


### PR DESCRIPTION
Hey,
I was investigating an issue with my project installation, and I've seen [this issue](https://github.com/npm/npm/issues/17723), and I've found that you accidentally published some files which are not supposed to be publish.

The cause of the issue is that `ansi-styles@2.2.0` is no longer available, but that was fine if you didn't publish the `.npm-shrinkwrap` which requires who ever installs you to download that version.

Adding this file and republishing to npm should solve future issues.