### PR TITLE
fix: editted ansi-styles in npm-shrinkwrap

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -13,9 +13,9 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
       "dependencies": {
         "ansi-styles": {
-          "version": "2.2.0",
-          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
+          "version": "2.2.1",
+          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "dependencies": {
             "color-convert": {
               "version": "1.0.0",


### PR DESCRIPTION
Since shrinkwrap was included in this repo, people who check it out and run `npm i` will get the specific versions that are defined. However ansi-styles (dependency of chalk) has version 2.2.0 referenced and this version was unpublished by the creator (read more here: https://github.com/chalk/ansi-styles/issues/15#issuecomment-202589714).

In this PR you will find that the version is changed to 2.2.1 which does exist.