### PR TITLE
Updated chalk to latest version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "async": "0.9.0",
-    "chalk": "^1.1.0",
+    "chalk": "^2.0.1",
     "dateformat": "1.0.11",
     "ejs": "~2.3.1",
     "extend": "^3.0.0",


### PR DESCRIPTION
This should fix this issue:

https://github.com/npm/npm/issues/17723

The issue is caused because for some reason ansi-styles 2.2.0 is no
longer available, which is what the old version of chalk which this
project used depends upon.