### PR TITLE
Explicitly fail on upload errors

### DIFF
--- a/tasks/lib/index.js
+++ b/tasks/lib/index.js
@@ -78,7 +78,8 @@ var createAndUploadArtifacts = function (options, done) {
                 '--output', '/dev/stderr',
                 '--write-out', '"%{http_code}"',
                 '--upload-file', fileLocation,
-                '--noproxy', options.noproxy ? options.noproxy : '127.0.0.1'
+                '--noproxy', options.noproxy ? options.noproxy : '127.0.0.1',
+                '--fail'
             ];
 
             if (options.auth) {


### PR DESCRIPTION
Use curl's `--fail` option to not mask errors.