### PR TITLE
Add binary encoding argument for node v6 support in generating sha1

### DIFF
--- a/tasks/lib/index.js
+++ b/tasks/lib/index.js
@@ -124,8 +124,8 @@ var createAndUploadArtifacts = function (options, done) {
 
         var binaryChunk = chunk.toString('binary');
 
-        md5Hash.update(binaryChunk);
-        sha1Hash.update(binaryChunk);
+        md5Hash.update(binaryChunk, 'binary');
+        sha1Hash.update(binaryChunk, 'binary');
     });
 
     artifactStream.on('error', function(error) {


### PR DESCRIPTION
Node v6 has the character encoding changed which results in a different hash being generated. See also https://github.com/nodejs/node/issues/6487

To fix this the update method needs to have the 'binary' argument added.